### PR TITLE
Add more flexible attributes parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,42 @@ All you need to do is download the file (or copy it's contents and put them in y
 include "grumpypdo.php";
 $db = new GrumpyPDO("localhost", "username", "password", "database");
 ```
+This will load all of the GrumpyPDO default attributes and the default charset for your connection, which are as follows:
 
-As of patch-1 you can also set PDO attributes and a charset on the fly.
+- PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+- PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+- PDO::ATTR_EMULATE_PREPARES => false,
+- charset: utf8
+
+You can also set PDO attributes and a charset on the fly.
 ```
 include "grumpypdo.php";
 
 $opt = [
-    "charset" => "utf8",
-    "options" => [
-    	PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-	PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-	PDO::ATTR_EMULATE_PREPARES => false,
-    ]
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
 ];
 
-$db = new GrumpyPDO("localhost", "username", "password", "database", $opt);
+$charset = "utf8";
+
+$db = new GrumpyPDO("localhost", "username", "password", "database", $opt, $charset);
 ```
+> Note: This will completely overwrite the GrumpyPDO defaults, so you must include any attributes you want, even if they are enabled by default by GrumpyPDO!
 
 > Note: In the example above with the `$opt` variable, these are the default settings of the class, but I was trying to show that you can set whatever you want there.
+
+But Grumpy, what if I want to use GrumpyPDO's default attributes but change my charset? You are able to do that as well! All you have to do is pass an empty array for the 5th parameter!
+
+```
+$db = new GrumpyPDO("localhost", "username", "password", "database", [], $charset);
+```
+
+Oh, so I can't choose to not use any attributes?? Pfft, of course you can! All you have to do is pass `NULL` to the 5th parameter! This will cause PDO to connect without any of the parameters, in other words, it will base it off of your PHP installation defaults.
+
+```
+$db = new GrumpyPDO("localhost", "username", "password", "database", NULL, $charset);
+```
 
 ## Simple Usage Instructions
 

--- a/grumpypdo.php
+++ b/grumpypdo.php
@@ -15,7 +15,7 @@ class GrumpyPdo extends \PDO
         if($attributes == NULL && !is_array($attributes)) {
             $attributes = array();
         } else {
-            if(empty($attributes)) $attributes = $this->default_attributes
+            if(empty($attributes)) $attributes = $this->default_attributes;
         }
         parent::__construct("mysql:host={$host};dbname={$db};charset={$charset}", $user, $pass, $atrributes);
     }

--- a/grumpypdo.php
+++ b/grumpypdo.php
@@ -1,40 +1,31 @@
 <?php
-
 class GrumpyPdo extends \PDO
 {
     /**
      * @var array
+	 * Default attributes set for database connection.
      */
-    protected $opt = array(
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, 
-        PDO::ATTR_DEFAULT_FETCH_MODE => 
-        PDO::FETCH_ASSOC, PDO::ATTR_EMULATE_PREPARES => false
+    protected $default_attributes = array(
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
     );
-
-    /**
-     * @var string
-     */
-    protected $charset = "utf8";
-
-    public function __construct($host, $user, $pass, $db, $opt = array())
+    public function __construct($host, $user, $pass, $db, $attributes = array(), $charset = "utf8")
     {
-        $charset = empty($opt['charset']) ? $this->charset : $opt['charset'];
-        $options = empty($opt['options']) ? $this->opt : $opt['options'];
-        parent::__construct($this->getDSN($host, $db, $charset), $user, $pass, $options);
+		if(!is_array($attributes)) {
+			$attributes = array();
+		} else {
+			if(empty($attributes)) $attributes = $this->default_attributes
+		}
+        parent::__construct("mysql:host={$host};dbname={$db};charset={$charset}", $user, $pass, $atrributes);
     }
-
     public function run($query, $values = array())
     {
-        if (!$values) {
+        if(!$values) {
             return $this->query($query);
         }
         $stmt = $this->prepare($query);
         $stmt->execute($values);
         return $stmt;
-    }
-
-    protected function getDSN($host, $db, $charset)
-    {
-        return "mysql:host={$host};dbname={$db};charset={$charset}";
     }
 }

--- a/grumpypdo.php
+++ b/grumpypdo.php
@@ -12,11 +12,11 @@ class GrumpyPdo extends \PDO
     );
     public function __construct($host, $user, $pass, $db, $attributes = array(), $charset = "utf8")
     {
-		if(!is_array($attributes)) {
-			$attributes = array();
-		} else {
-			if(empty($attributes)) $attributes = $this->default_attributes
-		}
+        if($attributes == NULL && !is_array($attributes)) {
+            $attributes = array();
+        } else {
+            if(empty($attributes)) $attributes = $this->default_attributes
+        }
         parent::__construct("mysql:host={$host};dbname={$db};charset={$charset}", $user, $pass, $atrributes);
     }
     public function run($query, $values = array())


### PR DESCRIPTION
I believe this will allow the attributes to be set easier. A user can simply call the class with the first 4 parameters for all default settings.

If the user chooses to, they can include an array as the 5th parameter to change the attributes given to the database connection.
If the user wants to keep the default attributes but change the charset, they can pass an empty array to the 5th parameter and set the chartet with the 6th parameter.

A user can can also pass NULL (or anything that is not an array) to the 5th parameter to send no attributes to the connection. I wanted this to be an option so people can turn off all attributes instead of it always defaulting to having what I had chosen to be important.

Originally I was going to make it so passing "NULL" to the 5th parameter was the only way to turn off all attributes, but I realized that an empty array also returns as a null, so that was a no go. Do you have any better ideas? @colshrapnel 

Please check the latest commit.