### PR TITLE
Patch 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,18 @@ Consider the table from above, and consider that we only want results of people 
 
 ```
 $name = "John";
-
 $stmt = $db->run("SELECT fname, lname FROM users WHERE fname=?", [$name])->fetchAll();
 //OR
-$stmt = $db->run("SELECT fname, lname FROM users WHERE fname=:name", ["name" => $name])->fetchAll();
-
-//OR
-
 $stmt = $db->all("SELECT fname, lname FROM users WHERE fname=?", [$name]);
+```
+
+You could also use named variables.
+
+```
+$name = "John";
+$stmt = $db->run("SELECT fname, lname FROM users WHERE fname=:name", ["name" => $name])->fetchAll();
 //OR
 $stmt = $db->all("SELECT fname, lname FROM users WHERE fname=:name", ["name" => $name]);
-
 ```
 
 The code above will return an array:

--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ Let's start with selecting all columns.
 
 ```
 $stmt = $db->run("SELECT `fname`, `lname` FROM users")->fetchAll();
+//OR
+$stmt = $db->all("SELECT `fname`, `lname` FROM users");
 ```
 
-Notice I used `fetchAll()` after the query, this is a "PDOStatement". Because the class returns the query as an object, you can use native PDO statement types, making this solution very powerful.
+Notice you can use `fetchAll()` after the query, this is a "PDOStatement". Because the class method `run()` returns the query as an object, you can use native PDO statement types, making this solution very powerful.
 [Here is some more PDOStatements that can be used with this class](http://php.net/manual/en/class.pdostatement.php)
+Or you can simply use the built in "Quick Queries" as noted in the code snippet above.
 
 Moving on, the above query will return an array that looks like this:
 
@@ -98,9 +101,17 @@ Consider the table from above, and consider that we only want results of people 
 
 ```
 $name = "John";
-$stmt = $db->run("SELECT * FROM users WHERE fname=?", [$name])->fetchAll();
+
+$stmt = $db->run("SELECT fname, lname FROM users WHERE fname=?", [$name])->fetchAll();
 //OR
-$stmt = $db->run("SELECT * FROM users WHERE fname=:name", ["name" => $name])->fetchAll();
+$stmt = $db->run("SELECT fname, lname FROM users WHERE fname=:name", ["name" => $name])->fetchAll();
+
+//OR
+
+$stmt = $db->all("SELECT fname, lname FROM users WHERE fname=?", [$name]);
+//OR
+$stmt = $db->all("SELECT fname, lname FROM users WHERE fname=:name", ["name" => $name]);
+
 ```
 
 The code above will return an array:
@@ -110,14 +121,12 @@ Array
 (
     [1] => Array
         (
-            [uid] => 1
             [fname] => John
             [lname] => Doe
         )
 
     [2] => Array
         (
-            [uid] => 4
             [fname] => John
             [lname] => Baldwin
         )

--- a/grumpypdo.php
+++ b/grumpypdo.php
@@ -17,8 +17,12 @@ class GrumpyPdo extends \PDO
     protected $last_affected_rows = 0;
     public function __construct($host, $user, $pass, $db, $attributes = array(), $charset = "utf8")
     {
-        if($attributes == NULL && !is_array($attributes)) {
-            $attributes = array();
+        if(!is_array($attributes)) {
+			if($attributes == NULL) {
+				$attributes = array();
+			} else {
+				$attributes = $this->default_attributes;
+			}
         } else {
             if(empty($attributes)) $attributes = $this->default_attributes;
         }

--- a/grumpypdo.php
+++ b/grumpypdo.php
@@ -18,11 +18,11 @@ class GrumpyPdo extends \PDO
     public function __construct($host, $user, $pass, $db, $attributes = array(), $charset = "utf8")
     {
         if(!is_array($attributes)) {
-			if($attributes == NULL) {
-				$attributes = array();
-			} else {
-				$attributes = $this->default_attributes;
-			}
+        if($attributes == NULL) {
+            $attributes = array();
+        } else {
+            $attributes = $this->default_attributes;
+        }
         } else {
             if(empty($attributes)) $attributes = $this->default_attributes;
         }

--- a/grumpypdo.php
+++ b/grumpypdo.php
@@ -18,11 +18,11 @@ class GrumpyPdo extends \PDO
     public function __construct($host, $user, $pass, $db, $attributes = array(), $charset = "utf8")
     {
         if(!is_array($attributes)) {
-        if($attributes == NULL) {
-            $attributes = array();
-        } else {
-            $attributes = $this->default_attributes;
-        }
+            if($attributes == NULL) {
+                $attributes = array();
+            } else {
+                $attributes = $this->default_attributes;
+            }
         } else {
             if(empty($attributes)) $attributes = $this->default_attributes;
         }

--- a/grumpypdo.php
+++ b/grumpypdo.php
@@ -3,13 +3,18 @@ class GrumpyPdo extends \PDO
 {
     /**
      * @var array
-	 * Default attributes set for database connection.
+     * Default attributes set for database connection.
      */
     protected $default_attributes = array(
         PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
         PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         PDO::ATTR_EMULATE_PREPARES   => false,
     );
+    /**
+     * @var int
+     * Holds the value of the amount of affected rows from the last query.
+     */
+    protected $last_affected_rows = 0;
     public function __construct($host, $user, $pass, $db, $attributes = array(), $charset = "utf8")
     {
         if($attributes == NULL && !is_array($attributes)) {
@@ -17,7 +22,7 @@ class GrumpyPdo extends \PDO
         } else {
             if(empty($attributes)) $attributes = $this->default_attributes;
         }
-        parent::__construct("mysql:host={$host};dbname={$db};charset={$charset}", $user, $pass, $atrributes);
+        parent::__construct("mysql:host={$host};dbname={$db};charset={$charset}", $user, $pass, $attributes);
     }
     public function run($query, $values = array())
     {
@@ -25,7 +30,38 @@ class GrumpyPdo extends \PDO
             return $this->query($query);
         }
         $stmt = $this->prepare($query);
-        $stmt->execute($values);
-        return $stmt;
+        if(!is_array($values[0])) {
+            return $stmt->execute($values);
+        }
+        $this->last_affected_rows = 0;
+        foreach($values as $value) 
+        {
+            $stmt->execute($value);
+            $this->last_affected_rows += $stmt->rowCount();
+        }
+        return $this->last_affected_rows;
+    }
+    /**
+     * Quick queries
+     * Allows you to run a query without chaining the return type manually. This allows for slightly shorter syntax.
+     */
+    public function row($query, $values = array()) 
+    {
+        return $this->run($query, $values)->fetch();
+    }
+    public function cell($query, $values = array()) 
+    {
+        return $this->run($query, $values)->fetchColumn();
+    }
+    public function all($query, $values = array()) 
+    {
+        return $this->run($query, $values)->fetchAll();
+    }
+    /**
+     * Other Methods
+     */
+    public function getLastAffectedRows() 
+    {
+        return $this->last_affected_rows;
     }
 }


### PR DESCRIPTION
Quick Queries:
Added a few methods to call specific types of returns easier. This includes 3 new methods, all of which call the main `run()` method.
- `row()`, fetch a specific row that qualifies based on query (chain `fetch()`)
- `cell()`, fetch a specific cell that qualifies based on query (chain `fetchColumn()`)
- `all()`, fetch all rows that qualify based on query (chain `fetchAll()`)

Altered `run()` to allow properly executing multiple statements with only 1 prepare. A user can pass a multi-dimensional array that contains an array for every DML query that they send. For example, if a user wants to insert 3 new users to their "user" table, they could do
```
$db->run("INSERT INTO users (fname, lname) VALUES (?, ?)", [["fname1", "lname1"], ["fname2", "lname2"], ["fname3", "lname3"]]
```

If there is more than 1 set of values passed, the function will always return the count of affected rows. If there is only 1 set of data sent, it will return an untouched object, and if no values are present, it will not `prepare()` at all, it will simpy use PDO's `query()`.

Another code section titled `Other Methods` was added, where extra methods will be placed such as the new `getLastAffectedRows()` method. This method will simply return the new `$last_affected_rows` variable, which will contain the number of affected rows from the last query.